### PR TITLE
Fix bug with slideshows on videos with autoplay

### DIFF
--- a/src/js/slideshow.js
+++ b/src/js/slideshow.js
@@ -91,7 +91,7 @@ var SlideShow;
             if (SlideShow.modalOpen()) {
                 SlideShow.next();
                 SlideShow.scheduleSlide(
-                    SlideShow.timeoutOverride != null ? slideTimeOverride : SlideShowHTML.getSlideSpeed()
+                    SlideShow.timeoutOverride != null ? SlideShow.timeoutOverride : SlideShowHTML.getSlideSpeed()
                 );
             }
         },


### PR DESCRIPTION
When the slideshow timer is active and Autoplay Video is on, if the next slide is a video, it will continue to the video but never advance further. This also causes an error of `Uncaught ReferenceError: slideTimeOverride is not defined`
I believe the `slideTimeOverride` meant to be `SlideShow.timeoutOverride`
First time making a pull request so sorry if something is wrong.