### PR TITLE
Bugfix double score display and vote status display

### DIFF
--- a/src/js/thumb.js
+++ b/src/js/thumb.js
@@ -140,8 +140,8 @@ var Thumbs;
                         const fav = $(".fav-buttons", data);
 
                         thumb.data("faved", fav.hasClass("fav-buttons-true"));
-                        thumb.data("voted", vup.parent().hasClass("score-positive") ? 1 : vdn.parent().hasClass("score-negative") ? -1 : 0);
-                        thumb.data("score", parseInt($("span.post-score", data).text()));
+                        thumb.data("voted", vup.find(".score-positive").hasClass("score-positive") ? 1 : vdn.find(".score-negative").hasClass("score-negative") ? -1 : 0);
+                        thumb.data("score", parseInt($("span.post-score", data).first().text()));
 
                         const content = $("#image-container", data);
                         thumb.data("content", content);


### PR DESCRIPTION
Sorry for the second pull request. I somehow managed to typo in just 2 lines of code.
fixes bug with the score display being shown double (like 34 likes would show as 3434)
The score display show the score twice because jquery finds 2 instances of span.post-score
The voted status display would not display unless you voted manually.

So as long as your signed in it will correctly show which posts you have upvoted and downvoted. And should correctly display the score
Its just a small visual bugfix but the bugs have been there for years.